### PR TITLE
fixing missing source attribute

### DIFF
--- a/src/Middleware/Grpc/Client/ClientApiRequestLogger.cs
+++ b/src/Middleware/Grpc/Client/ClientApiRequestLogger.cs
@@ -38,7 +38,9 @@ public class ClientApiRequestLogger : Interceptor
                             .ForContext(Constants.RequestIDLogKey, requestId)
                             .ForContext(Constants.ComponentFieldKey, Constants.ComponentValueClient)
                             .ForContext(Constants.MethodTypeFieldKey, context.Method.Type.ToString().ToLower())
-                            .ForContext(Constants.StartTimeKey, start.ToString("yyyy-MM-ddTHH:mm:sszzz"));
+                            .ForContext(Constants.StartTimeKey, start.ToString("yyyy-MM-ddTHH:mm:sszzz"))
+                            // readding here since source field seems to get removed, even after adding in interceptor.cs
+                            .ForContext("source", "ApiRequestLog");
 
         var response = continuation(request, context);
         Task.Run(() => HandleResponse(response, start, logger));

--- a/src/Middleware/Grpc/Common/Helpers.cs
+++ b/src/Middleware/Grpc/Common/Helpers.cs
@@ -9,8 +9,6 @@ public static class Helpers
     /// Extracts both the service and method names from a gRPC full method name.
     /// Expected format: "/package.Service/Method"
     /// </summary>
-    /// <param name="fullMethodName">The full gRPC method name.</param>
-    /// <returns>A tuple with ServiceName and MethodName.</returns>
     public static (string ServiceName, string MethodName) ExtractServiceAndMethod(string fullMethodName)
     {
         var parts = fullMethodName.Split('/');
@@ -19,7 +17,7 @@ public static class Helpers
             throw new InvalidOperationException("Unexpected gRPC method format.");
         }
 
-        string serviceName = parts[1].Split('.').Last(); // Get last portion as service name
+        string serviceName = parts[1].Split('.').Last();
         string methodName = parts[2];
         return (serviceName, methodName);
     }
@@ -30,9 +28,10 @@ public static class Helpers
     /// </summary>
     public static ILogger WithServiceProperties(this ILogger logger, string fullMethodName)
     {
-        var (serviceName, methodName) = Helpers.ExtractServiceAndMethod(fullMethodName);
-        return logger.ForContext(Constants.ServiceFieldKey, serviceName)
-                        .ForContext(Constants.MethodFieldKey, methodName)
-                        .ForContext(Constants.ProtocolKey, Constants.ProtocolValueGrpc);
+        var (serviceName, methodName) = ExtractServiceAndMethod(fullMethodName);
+        return logger
+                .ForContext(Constants.ServiceFieldKey, serviceName)
+                .ForContext(Constants.MethodFieldKey, methodName)
+                .ForContext(Constants.ProtocolKey, Constants.ProtocolValueGrpc);
     }
 }

--- a/src/Middleware/Grpc/Server/CtxLogger.cs
+++ b/src/Middleware/Grpc/Server/CtxLogger.cs
@@ -38,6 +38,8 @@ public class CtxLoggerInterceptor : Interceptor
             {
                 { Constants.MethodFieldKey, context.Method },
                 { "request", req },
+                // readding here since source field seems to get removed, even after adding in interceptor.cs
+                { "source", "CtxLog" },
                 { Constants.RequestIDLogKey, RequestIdInterceptor.GetRequestID(context) }
             };
             // Serialize the dictionary to a JSON string

--- a/src/Middleware/Grpc/Server/ServerApiRequestLogger.cs
+++ b/src/Middleware/Grpc/Server/ServerApiRequestLogger.cs
@@ -29,7 +29,9 @@ public class ServerApiRequestLogger : Interceptor
                             .ForContext(Constants.RequestIDLogKey, RequestIdInterceptor.GetRequestID(context))
                             .ForContext(Constants.StartTimeKey, start.ToString("yyyy-MM-ddTHH:mm:sszzz"))
                             .ForContext(Constants.PeerAddressKey, peerAddress)
-                            .WithServiceProperties(context.Method);
+                            .WithServiceProperties(context.Method)
+                            // readding here since source field seems to get removed, even after adding in interceptor.cs
+                            .ForContext("source", "ApiRequestLog");
 
         try
         {

--- a/src/Middleware/Middleware.csproj
+++ b/src/Middleware/Middleware.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>ServiceHub.AKSMiddleware</PackageId>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <Author>ServiceHub</Author>
     <Product>AKSMiddleware</Product>
   </PropertyGroup>

--- a/src/Middleware/Middleware.csproj
+++ b/src/Middleware/Middleware.csproj
@@ -9,7 +9,6 @@
     <Version>1.0.5</Version>
     <Author>ServiceHub</Author>
     <Product>AKSMiddleware</Product>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,10 +24,6 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="ServiceHub.LogProto" Version="1.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The source attribute is missing from the Server's ApiRequestLogger and CtxLogger. Reverting some changes so that the source field is added back to the logger context.